### PR TITLE
Fix null reference error when no event listeners are set for certain events

### DIFF
--- a/source/Client/Client.cs
+++ b/source/Client/Client.cs
@@ -301,7 +301,7 @@ namespace Nularc.Client
 			IsConnected = true;
 			ClientID = new Guid(packet.Reader.ReadBytes(16));
 
-			Connected.Invoke(ServerIPEndPoint, ClientID);
+			Connected?.Invoke(ServerIPEndPoint, ClientID);
 			Logger.LogInformation("Successfully connected to server {ServerIPEndPoint}, received client ID {ClientID}.", ServerIPEndPoint, ClientID);
 		}
 
@@ -314,7 +314,7 @@ namespace Nularc.Client
 			ServerIPEndPoint = null;
 			ClientID = Guid.Empty;
 
-			Disconnected.Invoke(serverIPEndPoint, clientID);
+			Disconnected?.Invoke(serverIPEndPoint, clientID);
 			Logger.LogInformation("Successfully disconnected from server {serverIPEndPoint}.", serverIPEndPoint);
 		}
 	}

--- a/source/Server/Server.cs
+++ b/source/Server/Server.cs
@@ -275,7 +275,7 @@ namespace Nularc.Server
 				SendPacket(newPacket, clientID);
 			}
 
-			ClientConnected.Invoke(ipEndPoint, clientID);
+			ClientConnected?.Invoke(ipEndPoint, clientID);
 			Logger.LogInformation("Client {clientID} ({IPEndPoint}) successfully connected.", clientID, IPEndPoint);
 		}
 
@@ -293,7 +293,7 @@ namespace Nularc.Server
 			ConnectedClientsIDToIP.Remove(ConnectedClientsIPToID[IPEndPoint]);
 			ConnectedClientsIPToID.Remove(IPEndPoint);
 
-			ClientDisconnected.Invoke(ipEndPoint, clientID);
+			ClientDisconnected?.Invoke(ipEndPoint, clientID);
 			Logger.LogInformation("Client {clientID} ({IPEndPoint}) successfully disconnected.", clientID, IPEndPoint);
 		}
 	}


### PR DESCRIPTION
I just added a few null checks. Should solve null reference errors when events are invoked but no event listeners are set.

Closes #18